### PR TITLE
Add Promotion to Production step to Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -210,11 +210,13 @@ steps:
     - pipeline/release_stage_cloud.sh
   when:
     event:
-      - tag
+      - promote
     status:
       - success
     repo:
       - astronomer/terraform-google-astronomer-cloud
+    target:
+      - staging
 
 - name: slack_staging
   image: plugins/slack
@@ -235,9 +237,11 @@ steps:
       {{/success}}
   when:
     event:
-      - tag
+      - promote
     status:
       - success
       - failure
     repo:
       - astronomer/terraform-google-astronomer-cloud
+    target:
+      - staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -54,10 +54,8 @@ steps:
     - cat abc.txt
   when:
     event:
-      - push
-      - tag
-    branch:
       - pull_request
+      - tag
 
 - name: terraform_plan
   image: sjmiller609/helm-kubectl-terraform:latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,16 @@
 kind: pipeline
 name: terraform-google-astronomer-cloud
 
+clone:
+  disable: true
+
 steps:
+
+- name: clone
+  image: docker:git
+  commands:
+  - git clone https://github.com/astronomer/terraform-google-astronomer-cloud
+  - git checkout $DRONE_COMMIT
 
 - name: lint
   image: hashicorp/terraform:light

--- a/.drone.yml
+++ b/.drone.yml
@@ -53,22 +53,10 @@ steps:
     - TF_PLAN=1 pipeline/release_stage_cloud.sh
   when:
     event:
-      - pull_request
-
-- name: deploy_to_production
-  image: sjmiller609/helm-kubectl-terraform:latest
-  environment:
-    GOOGLE_CREDENTIAL_FILE_CONTENT:
-      from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
-  commands:
-    - echo "works"
-  when:
-    event:
-      - promote
-    target:
-      - production
-    status:
-      - success
+      - push
+      - tag
+    branch:
+      - master
 
 - name: from_scratch
   image: sjmiller609/helm-kubectl-terraform:latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -46,29 +46,29 @@ steps:
 
 - name: terraform_plan
   image: sjmiller609/helm-kubectl-terraform:latest
-    environment:
-      GOOGLE_CREDENTIAL_FILE_CONTENT:
-        from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
-    commands:
-      - TF_PLAN=1 pipeline/release_stage_cloud.sh
-    when:
-      event:
-        - pull_request
+  environment:
+    GOOGLE_CREDENTIAL_FILE_CONTENT:
+      from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
+  commands:
+    - TF_PLAN=1 pipeline/release_stage_cloud.sh
+  when:
+    event:
+      - pull_request
 
 - name: deploy_to_production
   image: sjmiller609/helm-kubectl-terraform:latest
-    environment:
-      GOOGLE_CREDENTIAL_FILE_CONTENT:
-        from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
-    commands:
-      - echo "works"
-    when:
-      event:
-        - promote
-      target:
-        - production
-      status:
-        - success
+  environment:
+    GOOGLE_CREDENTIAL_FILE_CONTENT:
+      from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
+  commands:
+    - echo "works"
+  when:
+    event:
+      - promote
+    target:
+      - production
+    status:
+      - success
 
 - name: from_scratch
   image: sjmiller609/helm-kubectl-terraform:latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -39,10 +39,25 @@ steps:
     - terraform -v
     - rm providers.tf
     - rm ~/account.json
+    - echo "hi" >> abc.txt
   when:
     event:
       - pull_request
       - push
+
+- name: test
+  image: sjmiller609/helm-kubectl-terraform:latest
+  environment:
+    GOOGLE_CREDENTIAL_FILE_CONTENT:
+      from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
+  commands:
+    - cat abc.txt
+  when:
+    event:
+      - push
+      - tag
+    branch:
+      - pull_request
 
 - name: terraform_plan
   image: sjmiller609/helm-kubectl-terraform:latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,6 @@ steps:
     - terraform -v
     - rm providers.tf
     - rm ~/account.json
-    - echo "hi" >> abc.txt
   when:
     event:
       - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -167,6 +167,8 @@ steps:
     template: >
       {{repo.name}}
       version {{build.tag}} released
+      Run: `drone build promote astronomer/terraform-google-astronomer-cloud ${DRONE_BUILD_NUMBER} staging`
+      to run `terraform apply` and roll it to Staging Cluster
   when:
     event:
       - tag
@@ -184,7 +186,6 @@ steps:
     - TF_PLAN=1 pipeline/release_stage_cloud.sh
   when:
     event:
-      - push
       - tag
     branch:
       - master

--- a/.drone.yml
+++ b/.drone.yml
@@ -45,32 +45,6 @@ steps:
       - pull_request
       - push
 
-- name: test
-  image: sjmiller609/helm-kubectl-terraform:latest
-  environment:
-    GOOGLE_CREDENTIAL_FILE_CONTENT:
-      from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
-  commands:
-    - cat abc.txt
-  when:
-    event:
-      - pull_request
-      - tag
-
-- name: terraform_plan
-  image: sjmiller609/helm-kubectl-terraform:latest
-  environment:
-    GOOGLE_CREDENTIAL_FILE_CONTENT:
-      from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
-  commands:
-    - TF_PLAN=1 pipeline/release_stage_cloud.sh
-  when:
-    event:
-      - push
-      - tag
-    branch:
-      - master
-
 - name: from_scratch
   image: sjmiller609/helm-kubectl-terraform:latest
   environment:
@@ -202,13 +176,27 @@ steps:
     repo:
       - astronomer/terraform-google-astronomer-cloud
 
+- name: terraform_plan
+  image: sjmiller609/helm-kubectl-terraform:latest
+  environment:
+    GOOGLE_CREDENTIAL_FILE_CONTENT:
+      from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
+  commands:
+    - TF_PLAN=1 pipeline/release_stage_cloud.sh
+  when:
+    event:
+      - push
+      - tag
+    branch:
+      - master
+
 - name: deploy_to_staging
   image: sjmiller609/helm-kubectl-terraform:latest
   environment:
     GOOGLE_CREDENTIAL_FILE_CONTENT:
       from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
   commands:
-    - pipeline/release_stage_cloud.sh
+    - TF_APPLY=1 pipeline/release_stage_cloud.sh
   when:
     event:
       - promote

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,6 +44,32 @@ steps:
       - pull_request
       - push
 
+- name: terraform_plan
+  image: sjmiller609/helm-kubectl-terraform:latest
+    environment:
+      GOOGLE_CREDENTIAL_FILE_CONTENT:
+        from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
+    commands:
+      - TF_PLAN=1 pipeline/release_stage_cloud.sh
+    when:
+      event:
+        - pull_request
+
+- name: deploy_to_production
+  image: sjmiller609/helm-kubectl-terraform:latest
+    environment:
+      GOOGLE_CREDENTIAL_FILE_CONTENT:
+        from_secret: GOOGLE_CREDENTIAL_FILE_CONTENT_STAGING
+    commands:
+      - echo "works"
+    when:
+      event:
+        - promote
+      target:
+        - production
+      status:
+        - success
+
 - name: from_scratch
   image: sjmiller609/helm-kubectl-terraform:latest
   environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,16 +1,7 @@
 kind: pipeline
 name: terraform-google-astronomer-cloud
 
-clone:
-  disable: true
-
 steps:
-
-- name: clone
-  image: docker:git
-  commands:
-  - git clone https://github.com/astronomer/terraform-google-astronomer-cloud
-  - git checkout $DRONE_COMMIT
 
 - name: lint
   image: hashicorp/terraform:light

--- a/pipeline/release_stage_cloud.sh
+++ b/pipeline/release_stage_cloud.sh
@@ -7,6 +7,7 @@ set -xe
 ls /tmp | grep account
 
 export GOOGLE_APPLICATION_CREDENTIALS='/tmp/account.json'
+export TF_IN_AUTOMATION=true
 
 terraform -v
 
@@ -32,7 +33,9 @@ if [[ ${TF_PLAN:-0} -eq 1 ]]; then
 	  -var "deployment_id=$DEPLOYMENT_ID" \
 	  -var "dns_managed_zone=staging-zone" \
 	  -var "zonal=$ZONAL" \
-	  -lock=false
+	  -lock=false \
+	  -out=tfplan \
+	  -input=false
 fi
 
 if [[ ${TF_APPLY:-0} -eq 1 ]]; then
@@ -41,22 +44,8 @@ if [[ ${TF_APPLY:-0} -eq 1 ]]; then
 	  -var "dns_managed_zone=staging-zone" \
 	  -var "zonal=$ZONAL" \
 	  -lock=false \
-	  --target=module.astronomer_cloud.module.gcp
-
-	terraform apply --auto-approve \
-	  -var "deployment_id=$DEPLOYMENT_ID" \
-	  -var "dns_managed_zone=staging-zone" \
-	  -var "zonal=$ZONAL" \
-	  -lock=false \
 	  -refresh=false \
-	  --target=module.astronomer_cloud.local_file.kubeconfig
-
-	terraform apply --auto-approve \
-	  -var "deployment_id=$DEPLOYMENT_ID" \
-	  -var "dns_managed_zone=staging-zone" \
-	  -var "zonal=$ZONAL" \
-	  -lock=false \
-	  -refresh=false
+	  -input=false tfplan
 fi
 
 rm providers.tf

--- a/pipeline/release_stage_cloud.sh
+++ b/pipeline/release_stage_cloud.sh
@@ -25,7 +25,7 @@ sed -i "s/REPLACE/$DEPLOYMENT_ID/g" backend.tf
 sed -i "s/BUCKET/astronomer-staging-terraform-state/g" backend.tf
 sed -i "s/PROJECT/astronomer-cloud-staging/g" providers.tf
 
-terraform init
+#terraform init
 
 if [[ ${TF_PLAN:-0} -eq 1 ]]; then
 	terraform fmt -check=true

--- a/pipeline/release_stage_cloud.sh
+++ b/pipeline/release_stage_cloud.sh
@@ -28,11 +28,12 @@ sed -i "s/PROJECT/astronomer-cloud-staging/g" providers.tf
 terraform init
 
 if [[ ${TF_PLAN:-0} -eq 1 ]]; then
-	terraform plan -detailed-exitcode \
-	  -var "deployment_id=$DEPLOYMENT_ID" \
-	  -var "dns_managed_zone=staging-zone" \
-	  -var "zonal=$ZONAL" \
-	  -lock=false
+	terraform fmt -check=true
+#	terraform plan -detailed-exitcode \
+#	  -var "deployment_id=$DEPLOYMENT_ID" \
+#	  -var "dns_managed_zone=staging-zone" \
+#	  -var "zonal=$ZONAL" \
+#	  -lock=false
 fi
 
 if [[ ${TF_APPLY:-0} -eq 1 ]]; then

--- a/pipeline/release_stage_cloud.sh
+++ b/pipeline/release_stage_cloud.sh
@@ -27,27 +27,37 @@ sed -i "s/PROJECT/astronomer-cloud-staging/g" providers.tf
 
 terraform init
 
-terraform apply --auto-approve \
-  -var "deployment_id=$DEPLOYMENT_ID" \
-  -var "dns_managed_zone=staging-zone" \
-  -var "zonal=$ZONAL" \
-  -lock=false \
-  --target=module.astronomer_cloud.module.gcp
+if [[ ${TF_PLAN:-0} -eq 1 ]]; then
+	terraform plan -detailed-exitcode \
+	  -var "deployment_id=$DEPLOYMENT_ID" \
+	  -var "dns_managed_zone=staging-zone" \
+	  -var "zonal=$ZONAL" \
+	  -lock=false
+fi
 
-terraform apply --auto-approve \
-  -var "deployment_id=$DEPLOYMENT_ID" \
-  -var "dns_managed_zone=staging-zone" \
-  -var "zonal=$ZONAL" \
-  -lock=false \
-  -refresh=false \
-  --target=module.astronomer_cloud.local_file.kubeconfig
+if [[ ${TF_APPLY:-0} -eq 1 ]]; then
+	terraform apply --auto-approve \
+	  -var "deployment_id=$DEPLOYMENT_ID" \
+	  -var "dns_managed_zone=staging-zone" \
+	  -var "zonal=$ZONAL" \
+	  -lock=false \
+	  --target=module.astronomer_cloud.module.gcp
 
-terraform apply --auto-approve \
-  -var "deployment_id=$DEPLOYMENT_ID" \
-  -var "dns_managed_zone=staging-zone" \
-  -var "zonal=$ZONAL" \
-  -lock=false \
-  -refresh=false
+	terraform apply --auto-approve \
+	  -var "deployment_id=$DEPLOYMENT_ID" \
+	  -var "dns_managed_zone=staging-zone" \
+	  -var "zonal=$ZONAL" \
+	  -lock=false \
+	  -refresh=false \
+	  --target=module.astronomer_cloud.local_file.kubeconfig
+
+	terraform apply --auto-approve \
+	  -var "deployment_id=$DEPLOYMENT_ID" \
+	  -var "dns_managed_zone=staging-zone" \
+	  -var "zonal=$ZONAL" \
+	  -lock=false \
+	  -refresh=false
+fi
 
 rm providers.tf
 rm backend.tf

--- a/pipeline/release_stage_cloud.sh
+++ b/pipeline/release_stage_cloud.sh
@@ -28,7 +28,7 @@ sed -i "s/PROJECT/astronomer-cloud-staging/g" providers.tf
 #terraform init
 
 if [[ ${TF_PLAN:-0} -eq 1 ]]; then
-	terraform fmt -check=true
+	terraform fmt
 #	terraform plan -detailed-exitcode \
 #	  -var "deployment_id=$DEPLOYMENT_ID" \
 #	  -var "dns_managed_zone=staging-zone" \

--- a/pipeline/release_stage_cloud.sh
+++ b/pipeline/release_stage_cloud.sh
@@ -25,15 +25,14 @@ sed -i "s/REPLACE/$DEPLOYMENT_ID/g" backend.tf
 sed -i "s/BUCKET/astronomer-staging-terraform-state/g" backend.tf
 sed -i "s/PROJECT/astronomer-cloud-staging/g" providers.tf
 
-#terraform init
+terraform init
 
 if [[ ${TF_PLAN:-0} -eq 1 ]]; then
-	terraform fmt
-#	terraform plan -detailed-exitcode \
-#	  -var "deployment_id=$DEPLOYMENT_ID" \
-#	  -var "dns_managed_zone=staging-zone" \
-#	  -var "zonal=$ZONAL" \
-#	  -lock=false
+	terraform plan -detailed-exitcode \
+	  -var "deployment_id=$DEPLOYMENT_ID" \
+	  -var "dns_managed_zone=staging-zone" \
+	  -var "zonal=$ZONAL" \
+	  -lock=false
 fi
 
 if [[ ${TF_APPLY:-0} -eq 1 ]]; then


### PR DESCRIPTION
How it works?

Once the build passes on the master branch and a git tag is released, a `terraform_plan_staging_deployment` will be run in drone CI and it would show the the resources that would be created.

To approve once you confirm the plan we will have to run :

```
drone build promote astronomer/terraform-google-astronomer-cloud ${DRONE_BUILD_NUMBER} staging
```

This will run the `deploy_to_staging` & `slack_staging` tasks.