### PR TITLE
Add configuration for slack platform alerts

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -103,6 +103,16 @@ astronomer:
       enabled: true
       bucket: ${module.gcp.container_registry_bucket_name}
 %{endif}  
+%{if var.slack_alert_channel != "" && var.slack_alert_url != ""}
+alertmanager:
+  receivers:
+    platform:
+      slack_configs:
+      - channel: "${var.slack_alert_channel}"
+        api_url: "${var.slack_alert_url}"
+        title: "{{ .CommonAnnotations.summary }}"
+        text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+%{endif}
 
 EOF
 }

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,16 @@ variable "stripe_pk" {
   type    = string
 }
 
+variable "slack_alert_channel" {
+  default = ""
+  type    = string
+}
+
+variable "slack_alert_url" {
+  default = ""
+  type    = string
+}
+
 variable "dns_managed_zone" {
   default = ""
   type    = string


### PR DESCRIPTION
This PR adds support for pushing platform level alerts to a slack channel.