### PR TITLE
Add platformNodePool tolerations

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -18,6 +18,12 @@ global:
               operator: In
               values:
               - "false"
+    tolerations:
+      - key: "platform"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+
   deploymentNodePool:
     affinity:
       nodeAffinity:


### PR DESCRIPTION
This PR adds a `tolerations` to our platform components, which corresponds to the `taint` that @kaxil is adding to our platform node pool.

This is to force any airflow `KubernetesExecutor` / `KubernetesPodOperator` pods to not be scheduled on the platform node pool.