### PR TITLE
NetworkPolicy for Cloud SQL proxy

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -260,6 +260,23 @@ schedules:
       ttl: "720h"
 EOF
 
+  extra_googlesqlproxy_helm_values = <<EOF
+---
+networkPolicy:
+  enabled: true
+  ingress:
+    from:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            tier: airflow
+            component: pgbouncer
+      - podSelector:
+          matchLabels:
+            tier: astronomer
+            component: prisma
+EOF
+
   tiller_tolerations = [
     {
       key      = "platform",

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ module "gcp" {
 module "system_components" {
   dependencies = [module.gcp.depended_on]
   source       = "astronomer/astronomer-system-components/kubernetes"
-  version      = "0.1.12"
+  version      = "0.1.13"
   //  source                       = "../terraform-kubernetes-astronomer-system-components"
   enable_cloud_sql_proxy       = true
   enable_istio                 = var.enable_istio


### PR DESCRIPTION
Closes https://github.com/astronomer/issues/issues/409

The only other place I know that this gets used is when Andrew does the port forward to his local in order to assist with DB migrations. I wouldn't expect this to block that, but I'm not sure.

Merge when you want. There is some risk that it will break the platform, so let me know when you have merged it. I didn't deploy a cluster just to test this.