### PR TITLE
Fix probe settings

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -260,6 +260,22 @@ schedules:
       ttl: "720h"
 EOF
 
+  extra_googlesqlproxy_helm_values = <<EOF
+---
+networkPolicy:
+  enabled: true
+  ingress:
+    from:
+      - podSelector:
+          matchLabels:
+            tier: airflow
+            component: pgbouncer
+      - podSelector:
+          matchLabels:
+            tier: astronomer
+            component: prisma
+EOF
+
   tiller_tolerations = [
     {
       key      = "platform",

--- a/locals.tf
+++ b/locals.tf
@@ -133,11 +133,10 @@ astronomer:
             - name: AIRFLOW__WEBSERVER__ANALYTICS_ID
               value: "tH2XzkxCDpdC8Jvn8YroJ"
           webserver:
-            livenessProbe:
-              initialDelaySeconds: 15
-              timeoutSeconds: 30
-              failureThreshold: 60
-              periodSeconds: 8
+            initialDelaySeconds: 15
+            timeoutSeconds: 30
+            failureThreshold: 60
+            periodSeconds: 8
           pgbouncer:
             resultBackendPoolSize: 10
           affinity:

--- a/locals.tf
+++ b/locals.tf
@@ -78,12 +78,6 @@ astronomer:
         enabled: true
         smtpUrl: ${var.smtp_uri}
     %{endif}
-      helm:
-        env:
-          - name: AIRFLOW__WEBSERVER__ANALYTICS_TOOL
-            value: "metarouter"
-          - name: AIRFLOW__WEBSERVER__ANALYTICS_ID
-            value: "tH2XzkxCDpdC8Jvn8YroJ"
       deployments:
         maxExtraAu: 1000
         maxPodAu: 100
@@ -133,6 +127,17 @@ astronomer:
         astroUnit:
           price: 10
         helm:
+          env:
+            - name: AIRFLOW__WEBSERVER__ANALYTICS_TOOL
+              value: "metarouter"
+            - name: AIRFLOW__WEBSERVER__ANALYTICS_ID
+              value: "tH2XzkxCDpdC8Jvn8YroJ"
+          webserver:
+            livenessProbe:
+              initialDelaySeconds: 15
+              timeoutSeconds: 30
+              failureThreshold: 60
+              periodSeconds: 8
           pgbouncer:
             resultBackendPoolSize: 10
           affinity:

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ module "astronomer" {
   dependencies       = [module.system_components.depended_on, module.gcp.depended_on]
   source             = "astronomer/astronomer/kubernetes"
   version            = "1.1.20"
-  astronomer_version = "0.10.3-alpha.4"
+  astronomer_version = "0.10.2"
 
   db_connection_string = "postgres://${module.gcp.db_connection_user}:${module.gcp.db_connection_password}@pg-sqlproxy-gcloud-sqlproxy.astronomer:5432"
   tls_cert             = var.tls_cert == "" ? module.gcp.tls_cert : var.tls_cert

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ module "system_components" {
   gcp_project                  = module.gcp.gcp_project
   extra_istio_helm_values      = local.extra_istio_helm_values
   istio_helm_release_version   = "1.3.0"
-  kubecost_helm_chart_version  = "1.45.0"
+  kubecost_helm_chart_version  = "1.45.1"
   enable_velero                = var.enable_velero
   extra_velero_helm_values     = local.extra_velero_helm_values
   tiller_tolerations           = local.tiller_tolerations

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ module "system_components" {
   extra_istio_helm_values      = local.extra_istio_helm_values
   istio_helm_release_version   = "1.3.0"
   kubecost_helm_chart_version  = "1.45.1"
+  tiller_version               = "2.15.0"
   enable_velero                = var.enable_velero
   extra_velero_helm_values     = local.extra_velero_helm_values
   tiller_tolerations           = local.tiller_tolerations


### PR DESCRIPTION
both liveness and readiness probes will get this config because the helm chart shares the configs b/w the two.
```
          livenessProbe:
            httpGet:
              path: /health
              port: {{ .Values.ports.airflowUI }}
            initialDelaySeconds: {{ .Values.webserver.initialDelaySeconds | default 15 }}
            timeoutSeconds: {{ .Values.webserver.timeoutSeconds | default 30 }}
            failureThreshold: {{ .Values.webserver.failureThreshold | default 20 }}
            periodSeconds: {{ .Values.webserver.periodSeconds | default 5 }}
          readinessProbe:
            httpGet:
              path: /health
              port: {{ .Values.ports.airflowUI }}
            initialDelaySeconds: {{ .Values.webserver.initialDelaySeconds | default 15 }}
            timeoutSeconds: {{ .Values.webserver.timeoutSeconds | default 30 }}
            failureThreshold: {{ .Values.webserver.failureThreshold | default 20 }}
            periodSeconds: {{ .Values.webserver.periodSeconds | default 5 }}
```