### PR TITLE
Horizontally scale the SQL proxy

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -275,6 +275,7 @@ EOF
 
   extra_googlesqlproxy_helm_values = <<EOF
 ---
+replicasCount: 5
 networkPolicy:
   enabled: true
   ingress:

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ module "astronomer" {
   dependencies       = [module.system_components.depended_on, module.gcp.depended_on]
   source             = "astronomer/astronomer/kubernetes"
   version            = "1.1.20"
-  astronomer_version = "0.10.3-rc.1"
+  astronomer_version = "0.10.2-fix.1"
 
   db_connection_string = "postgres://${module.gcp.db_connection_user}:${module.gcp.db_connection_password}@pg-sqlproxy-gcloud-sqlproxy.astronomer:5432"
   tls_cert             = var.tls_cert == "" ? module.gcp.tls_cert : var.tls_cert


### PR DESCRIPTION
We can't push to prod until we either rollback the helm version or get a stable helm chart for 0.10.3

This is an attempt to fix https://github.com/astronomer/issues/issues/497

We can see that istio is running hot on SQL proxy

![image](https://user-images.githubusercontent.com/7516283/67576287-458c4680-f70c-11e9-9813-ad6bb4bb1063.png)
