### PR TITLE
Send Airflow alerts to slack

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -172,6 +172,19 @@ alertmanager:
             {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
             {{ end }}
           {{ end }}
+    airflow:
+      slack_configs:
+      - channel: "${var.slack_alert_channel}"
+        api_url: "${var.slack_alert_url}"
+        title: "{{ .CommonAnnotations.summary }}"
+        text: |-
+          {{ range .Alerts }}
+            *Alert:* {{ .Annotations.summary }}
+            *Description:* {{ .Annotations.description }}
+            *Details:*
+            {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+            {{ end }}
+          {{ end }}
 %{if var.pagerduty_service_key != ""}
       pagerduty_configs:
       - routing_key: "${var.pagerduty_service_key}"

--- a/locals.tf
+++ b/locals.tf
@@ -173,6 +173,9 @@ alertmanager:
             {{ end }}
           {{ end }}
     airflow:
+      webhook_configs:
+      - url: "http://{{ .Release.Name }}-houston:8871/v1/alerts"
+        send_resolved: true
       slack_configs:
       - channel: "${var.slack_alert_channel}"
         api_url: "${var.slack_alert_url}"


### PR DESCRIPTION
Closes https://github.com/astronomer/issues/issues/505

This will send Airflow alerts to the same slack channel as the other alerts. I think this is fine because pager duty will still only alert for the platform alerts, and there is no reason for customer success to not be aware of a platform-level alert.