### PR TITLE
Scale platform node pool, ES client, and Prometheus

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -49,6 +49,11 @@ nginx:
   privateLoadBalancer: false
   perserveSourceIP: true
 astronomer:
+  images:
+    registry:
+      repository: registry
+      tag: 2.7.1
+      pullPolicy: IfNotPresent
   orbit:
     env:
       - name: ANALYTICS_TRACKING_ID
@@ -228,10 +233,10 @@ prometheus:
   resources:
     requests:
       cpu: "1000m"
-      memory: "4Gi"
-    limits:
-      cpu: "2000m"
       memory: "16Gi"
+    limits:
+      cpu: "4000m"
+      memory: "32Gi"
 EOF
 
   extra_istio_helm_values = <<EOF

--- a/locals.tf
+++ b/locals.tf
@@ -48,6 +48,9 @@ nginx:
   # For cloud, the load balancer should be public
   privateLoadBalancer: false
   perserveSourceIP: true
+elasticsearch:
+  data:
+    replicas: 4
 astronomer:
   images:
     registry:

--- a/main.tf
+++ b/main.tf
@@ -27,9 +27,10 @@ module "gcp" {
   lets_encrypt = var.lets_encrypt
 
   # Instance sizes
-  machine_type   = var.worker_node_size
-  max_node_count = var.max_worker_node_count
-  cloud_sql_tier = var.db_instance_size
+  machine_type          = var.worker_node_size
+  machine_type_platform = "n1-standard-16"
+  max_node_count        = var.max_worker_node_count
+  cloud_sql_tier        = var.db_instance_size
 
   # Only allow platform pods to created on this NodePool by using the below taint
   # Unless pods has the matching key,value for the taint the pods would not be
@@ -87,7 +88,7 @@ module "astronomer" {
   dependencies       = [module.system_components.depended_on, module.gcp.depended_on]
   source             = "astronomer/astronomer/kubernetes"
   version            = "1.1.20"
-  astronomer_version = "0.10.3-fix.1"
+  astronomer_version = "0.10.3-fix.2"
 
   db_connection_string = "postgres://${module.gcp.db_connection_user}:${module.gcp.db_connection_password}@pg-sqlproxy-gcloud-sqlproxy.astronomer:5432"
   tls_cert             = var.tls_cert == "" ? module.gcp.tls_cert : var.tls_cert


### PR DESCRIPTION
This is a bundle of short-term stability changes

- Changes the helm chart like this: https://github.com/astronomer/helm.astronomer.io/pull/248
- scale network on elasticsearch client (caused logs to not load for tasks that log a lot)
- add in patch for registry image to code
- increase limits on prometheus
- increase the size of the nodes in platform node pool to accommodate prometheus