### PR TITLE
Add new channel for just platform alerts

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -217,6 +217,17 @@ alertmanager:
             {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
             {{ end }}
           {{ end }}
+      - channel: "${var.slack_alert_channel}-platform"
+        api_url: "${var.slack_alert_url}"
+        title: "{{ .CommonAnnotations.summary }}"
+        text: |-
+          {{ range .Alerts }}
+            *Alert:* {{ .Annotations.summary }}
+            *Description:* {{ .Annotations.description }}
+            *Details:*
+            {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+            {{ end }}
+          {{ end }}
 %{if var.pagerduty_service_key != ""}
       pagerduty_configs:
       - routing_key: "${var.pagerduty_service_key}"


### PR DESCRIPTION
the point of this change is to have a slack channel that only shows platform alerts