### PR TITLE
Add replica Prometheus

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -253,6 +253,7 @@ alertmanager:
           {{ end }}
 %{endif}
 prometheus:
+  replicas: 2
   persistence:
     size: "400Gi"
   # We bill ~30d, so let's retain all metrics for

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ module "astronomer" {
   dependencies       = [module.system_components.depended_on, module.gcp.depended_on]
   source             = "astronomer/astronomer/kubernetes"
   version            = "1.1.20"
-  astronomer_version = "0.10.3-fix.6"
+  astronomer_version = "0.10.3-astro.7"
 
   db_connection_string = "postgres://${module.gcp.db_connection_user}:${module.gcp.db_connection_password}@pg-sqlproxy-gcloud-sqlproxy.astronomer:5432"
   tls_cert             = var.tls_cert == "" ? module.gcp.tls_cert : var.tls_cert


### PR DESCRIPTION
helm chart changes: https://github.com/astronomer/helm.astronomer.io/pull/280/files

master PR: https://github.com/astronomer/helm.astronomer.io/pull/278

Pros:
- Two Prometheuses (two pods, two volumes, two services, one stateful set)

Cons:
- 800GB total storage (up to 1600GB for stage and prod proms from 800GB) on both stage and prod for these. We can reconfigure a lot smaller I expect after 35 days (old, heavier data falls out of retention window), but we will need to either allow all data to be deleted or do something to migrate the existing data to smaller volumes