### PR TITLE
Set max_connections DB flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ module "gcp" {
   machine_type_platform = "n1-standard-16"
   max_node_count        = var.max_worker_node_count
   cloud_sql_tier        = var.db_instance_size
+  db_max_connections    = 1000
 
   # Only allow platform pods to created on this NodePool by using the below taint
   # Unless pods has the matching key,value for the taint the pods would not be


### PR DESCRIPTION
Closes https://github.com/astronomer/issues/issues/630

Enabled by this change https://github.com/astronomer/terraform-google-astronomer-gcp/pull/37

It does not destroy and recreate the DB. On a dev environment, it only took a few seconds to update, but I can't be sure for an active DB. When this is merged, it will deploy to stage cloud automatically. Then we decide to release to prod using the drone release command.