### PR TITLE
Add configuration to decouple airflow chart and images

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -158,6 +158,12 @@ astronomer:
         %{endif}
         astroUnit:
           price: 10
+        chart:
+          version: 0.11.0-rc.1
+        images:
+          - version: 1.10.5
+            channel: stable
+            tag: 1.10.5-alpine3.10-onbuild
         helm:
           webserver:
             initialDelaySeconds: 15

--- a/locals.tf
+++ b/locals.tf
@@ -161,7 +161,7 @@ astronomer:
         astroUnit:
           price: 10
         chart:
-          version: 0.11.0-rc.1
+          version: 0.11.0-rc.3
         images:
           - version: 1.10.5
             channel: stable

--- a/locals.tf
+++ b/locals.tf
@@ -82,6 +82,8 @@ astronomer:
         value: "${var.stripe_pk}"
   %{endif}
   houston:
+    expireDeployments:
+      enabled: true
     env:
       - name: ANALYTICS__ENABLED
         value: "true"

--- a/variables.tf
+++ b/variables.tf
@@ -158,7 +158,7 @@ variable "enable_knative" {
 
 variable "create_dynamic_pods_nodepool" {
   type        = bool
-  default     = false
+  default     = true
   description = "If true, creates a NodePool for the pods spun up using KubernetesPodsOperator or KubernetesExecutor"
 }
 


### PR DESCRIPTION
This PR should trigger all existing airflow deployments to upgrade to the RC, and adds the list of supported platform images.

@kaxil should we add the new releases? These are used by the CLI to ensure the users images are compatible. It validates the user is pushing one of these, and will use the largest version in the stable channel as the default during `astro dev init`.