### PR TITLE
Turn dry-run on for expire-deployments

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -87,6 +87,7 @@ astronomer:
   houston:
     expireDeployments:
       enabled: true
+      dryRun: true
     env:
       - name: ANALYTICS__ENABLED
         value: "true"

--- a/locals.tf
+++ b/locals.tf
@@ -85,7 +85,12 @@ astronomer:
   norbit:
     enabled: true
   houston:
+    upgradeDeployments:
+      enabled: true
     expireDeployments:
+      enabled: true
+      dryRun: true
+    cleanupDeployments:
       enabled: true
       dryRun: true
     env:


### PR DESCRIPTION
This PR temporarily flags the deployment expiration as a dry-run until we know what to expect in a live environment.