### PR TITLE
Release branch tags

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -74,6 +74,14 @@ astronomer:
       repository: registry
       tag: 2.7.1
       pullPolicy: IfNotPresent
+    orbit:
+      repository: astronomerinc/ap-orbit-ui
+      tag: release-0.11
+      pullPolicy: Always
+    houston:
+      repository: astronomerinc/ap-houston-api
+      tag: release-0.11
+      pullPolicy: Always
   orbit:
     env:
       - name: ANALYTICS_TRACKING_ID

--- a/locals.tf
+++ b/locals.tf
@@ -110,9 +110,6 @@ astronomer:
         value: "true"
     %{endif}
     config:
-      cors:
-        allowedOrigins:
-          - https://orbit-dev.netlify.com/
     %{if var.public_signups}
       publicSignups: true
     %{else}


### PR DESCRIPTION
This PR temporarily points houston and orbit at release-0.11 branches. Also cleans up old netlify config.