### PR TITLE
Turn on Houston job features

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -92,10 +92,11 @@ astronomer:
       dryRun: true
       canary: false
     cleanupDeployments:
+      enabled: true
       dryRun: true
       canary: false
     upgradeDeployments:
-      enabled: false
+      enabled: true
       canary: false
     env:
       - name: ANALYTICS__ENABLED


### PR DESCRIPTION
This change will be needed in order to actually deploy the airflow chart updates.