### PR TITLE
Optionally provide Astronomer's helm values

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  astronomer_helm_values = <<EOF
+  astronomer_helm_values = var.astronomer_helm_values != "" ? var.astronomer_helm_values : <<EOF
 ---
 global:
   # Base domain for all subdomains exposed through ingress

--- a/variables.tf
+++ b/variables.tf
@@ -167,3 +167,9 @@ variable "enable_gke_metered_billing" {
   default     = true
   description = "If true, enables GKE metered billing to track costs on namespaces & label level"
 }
+
+variable "astronomer_helm_values" {
+  type        = string
+  default     = ""
+  description = "The Helm values to apply to the Astronomer platform. This yaml block will the Helm user-provided values for the Astronomer installation, if provided."
+}


### PR DESCRIPTION
For the sake of simplifying the configuration of our terraform on GCP, we should allow providing the helm values externally, instead of using TF variables to template a block in locals.tf (which I have found to be overly complicated). Rather that completely re-working the logic immediately, we can instead provide it optionally, then remove the block in locals.tf after our environments are successfully making use of the externally provided configurations.

For the sake of https://github.com/astronomer/issues/issues/756