### PR TITLE
Add safe-to-evict annoation to cloud sql proxy

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -519,6 +519,7 @@ replicasCount: 10
 podAnnotations:
   sidecar.istio.io/proxyCPU: "1000m"
   sidecar.istio.io/proxyMemory: "300Mi"
+  cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 EOF
   extra_kubecost_helm_values       = <<EOF
 ---


### PR DESCRIPTION
This PR adds the safe-to-evict to our google cloud sql proxy pods. This will allow these pods to be evicted to scale our clusters down. It's needed because these pods are using localStroage.