### PR TITLE
fix for sql proxy using older `apiVersion` on their deployment manifest

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # Networks, Database, Kubernetes cluster, etc.
 module "gcp" {
 
-  source =  "github.com/astronomer/terraform-google-astronomer-gcp?ref=tommy-gke-channels"
+  source =  "github.com/astronomer/terraform-google-astronomer-gcp?ref=gke-channels"
   
   email                   = var.email
   deployment_id           = var.deployment_id

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ module "system_components" {
   gcp_project                        = module.gcp.gcp_project
   extra_istio_helm_values            = local.extra_istio_helm_values
   extra_googlesqlproxy_helm_values   = local.extra_googlesqlproxy_helm_values
-  cloud_sql_proxy_helm_chart_version = "0.19.2"
+  cloud_sql_proxy_helm_chart_version = "0.19.6"
   istio_helm_release_version         = "1.4.3"
   kubecost_helm_chart_version        = "1.45.1"
   tiller_version                     = var.tiller_version

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # Networks, Database, Kubernetes cluster, etc.
 module "gcp" {
 
-  source =  "github.com/astronomer/terraform-google-astronomer-gcp?ref=gke-channels"
+  source =  "github.com/astronomer/terraform-google-astronomer-gcp?ref=tommy-gke-channels"
   
   email                   = var.email
   deployment_id           = var.deployment_id


### PR DESCRIPTION
i bumped to the closest version that had that change according to the github tags.  there are even newer releases but i figured i wouldn't rock the boat to hard and just get to where we needed to be...

thoughts?