### PR TITLE
Use ipify vs icanhazip

### DIFF
--- a/pipeline/run_terraform.sh
+++ b/pipeline/run_terraform.sh
@@ -52,8 +52,8 @@ if [ $DESTROY -eq 1 ]; then
     set +e
 
     # whitelist our current IP for kube management API
-    gcloud container clusters update $DEPLOYMENT_ID-cluster --enable-master-authorized-networks --master-authorized-networks="$(curl icanhazip.com)/32" --zone=us-east4-a
-    
+    gcloud container clusters update $DEPLOYMENT_ID-cluster --enable-master-authorized-networks --master-authorized-networks="$(curl -sS https://api.ipify.org)/32" --zone=us-east4-a
+
     # copy the kubeconfig from the terraform state
     terraform state pull | jq -r '.resources[] | select(.module == "module.astronomer_cloud") | select(.name == "kubeconfig") | .instances[0].attributes.content' > kubeconfig
     chmod 755 kubeconfig


### PR DESCRIPTION
icanhazip.com has caused some issues in the past due to being unavailable. This change swiches to ipify.org

Example failure: <https://app.circleci.com/pipelines/github/astronomer/google-environments/8177/workflows/acd7356d-f3a3-4cdb-9628-a26eebe53192/jobs/11737>

Related to astronomer/issues#2290