### PR TITLE
Gke channels

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -116,7 +116,7 @@ steps:
   commands:
     - eval `ssh-agent`
     - echo "$DEPLOY_KEY" | ssh-add -
-    - TAG=0.1.${DRONE_BUILD_NUMBER}
+    - TAG=0.2.${DRONE_BUILD_NUMBER}
     - git tag $TAG
     - mkdir -p $HOME/.ssh
     - ssh-keyscan -t rsa github.com >> $HOME/.ssh/known_hosts

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ module "system_components" {
   gcp_project                        = module.gcp.gcp_project
   extra_istio_helm_values            = local.extra_istio_helm_values
   extra_googlesqlproxy_helm_values   = local.extra_googlesqlproxy_helm_values
-  cloud_sql_proxy_helm_chart_version = "0.19.2"
+  cloud_sql_proxy_helm_chart_version = "0.19.6"
   istio_helm_release_version         = "1.4.3"
   kubecost_helm_chart_version        = "1.45.1"
   tiller_version                     = var.tiller_version

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,7 @@
 # Networks, Database, Kubernetes cluster, etc.
 module "gcp" {
 
-  source =  "github.com/astronomer/terraform-google-astronomer-gcp"
-  ref = "gke-channels"
+  source =  "github.com/astronomer/terraform-google-astronomer-gcp?ref=gke-channels"
   
   email                   = var.email
   deployment_id           = var.deployment_id

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ module "gcp" {
 module "system_components" {
   dependencies = [module.gcp.depended_on]
 
- source = "github.com/astronomer/terraform-kubernetes-astronomer?ref=gke-channels"
+ source = "github.com/astronomer/terraform-kubernetes-astronomer-system-components"
 
   astronomer_namespace               = var.astronomer_namespace
   enable_cloud_sql_proxy             = var.enable_cloud_sql_proxy

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # Networks, Database, Kubernetes cluster, etc.
 module "gcp" {
 
-  source = "github.com/astronomer/terraform-google-astronomer-gcp?ref=1.1.0"
+  source = "github.com/astronomer/terraform-google-astronomer-gcp?ref=1.1.2"
 
   email                   = var.email
   deployment_id           = var.deployment_id
@@ -79,6 +79,7 @@ module "gcp" {
   dynamic_blue_np_initial_node_count   = var.dynamic_blue_np_initial_node_count
   machine_type_dynamic_blue            = var.machine_type_dynamic_blue
   disk_size_dynamic_blue               = var.disk_size_dynamic_blue
+  disk_type_dynamic_blue               = var.disk_type_dynamic_blue
   max_node_count_dynamic_blue          = var.max_node_count_dynamic_blue
   dynamic_blue_node_pool_taints        = var.dynamic_blue_node_pool_taints
   enable_gvisor_dynamic_blue           = var.enable_gvisor_dynamic_blue
@@ -86,6 +87,7 @@ module "gcp" {
   dynamic_green_np_initial_node_count  = var.dynamic_green_np_initial_node_count
   machine_type_dynamic_green           = var.machine_type_dynamic_green
   disk_size_dynamic_green              = var.disk_size_dynamic_green
+  disk_type_dynamic_green              = var.disk_type_dynamic_green
   max_node_count_dynamic_green         = var.max_node_count_dynamic_green
   dynamic_green_node_pool_taints       = var.dynamic_green_node_pool_taints
   enable_gvisor_dynamic_green          = var.enable_gvisor_dynamic_green

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,9 @@
 # Networks, Database, Kubernetes cluster, etc.
 module "gcp" {
 
-  source                  = "astronomer/astronomer-gcp/google"
-  version                 = "1.0.265"
+  source =  "github.com/astronomer/terraform-google-astronomer-gcp"
+  ref = "gke-channels"
+  
   email                   = var.email
   deployment_id           = var.deployment_id
   dns_managed_zone        = var.dns_managed_zone
@@ -127,8 +128,10 @@ module "astronomer" {
   astronomer_helm_chart_repo_url  = var.astronomer_helm_chart_repo_url
 
   db_connection_string = "postgres://${module.gcp.db_connection_user}:${module.gcp.db_connection_password}@pg-sqlproxy-gcloud-sqlproxy.astronomer:5432"
-  tls_cert             = var.tls_cert == "" ? module.gcp.tls_cert : var.tls_cert
-  tls_key              = var.tls_key == "" ? module.gcp.tls_key : var.tls_key
+  # If var.tls_cert is an empty string then the result is "var.tls_cert", 
+  # but otherwise it is the actual value of var.tls_cert.
+  tls_cert = var.tls_cert == "" ? module.gcp.tls_cert : var.tls_cert
+  tls_key  = var.tls_key == "" ? module.gcp.tls_key : var.tls_key
 
   gcp_default_service_account_key = module.gcp.gcp_default_service_account_key
 

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ module "gcp" {
 module "system_components" {
   dependencies = [module.gcp.depended_on]
 
- source = "https://github.com/astronomer/terraform-kubernetes-astronomer?ref=gke-channels"
+ source = "github.com/astronomer/terraform-kubernetes-astronomer?ref=gke-channels"
 
   astronomer_namespace               = var.astronomer_namespace
   enable_cloud_sql_proxy             = var.enable_cloud_sql_proxy

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # Networks, Database, Kubernetes cluster, etc.
 module "gcp" {
 
-  source = "github.com/astronomer/terraform-google-astronomer-gcp?ref=1.1.2"
+  source = "github.com/astronomer/terraform-google-astronomer-gcp?ref=1.1.3"
 
   email                   = var.email
   deployment_id           = var.deployment_id
@@ -91,6 +91,7 @@ module "gcp" {
   max_node_count_dynamic_green         = var.max_node_count_dynamic_green
   dynamic_green_node_pool_taints       = var.dynamic_green_node_pool_taints
   enable_gvisor_dynamic_green          = var.enable_gvisor_dynamic_green
+  natgateway_external_ip_list          = var.natgateway_external_ip_list
 }
 
 # Install tiller, which is the server-side component

--- a/main.tf
+++ b/main.tf
@@ -112,8 +112,9 @@ module "system_components" {
 module "astronomer" {
   dependencies = [module.system_components.depended_on, module.gcp.depended_on]
 
-  source  = "astronomer/astronomer/kubernetes"
-  version = "1.1.90"
+  #source  = "astronomer/astronomer/kubernetes"
+  #version = "1.1.90"
+  source = "github.com/astronomer/terraform-kubernetes-astronomer?ref=gke-channels"
 
   astronomer_namespace            = var.astronomer_namespace
   install_astronomer_helm_chart   = var.install_astronomer_helm_chart

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # Networks, Database, Kubernetes cluster, etc.
 module "gcp" {
 
-  source = "github.com/astronomer/terraform-google-astronomer-gcp?ref=gke-channels"
+  source = "github.com/astronomer/terraform-google-astronomer-gcp?ref=1.1.0"
 
   email                   = var.email
   deployment_id           = var.deployment_id

--- a/main.tf
+++ b/main.tf
@@ -141,7 +141,8 @@ module "astronomer" {
   astronomer_helm_chart_repo      = var.astronomer_helm_chart_repo
   astronomer_helm_chart_repo_url  = var.astronomer_helm_chart_repo_url
 
-  db_connection_string = "postgres://${module.gcp.db_connection_user}:${module.gcp.db_connection_password}@pg-sqlproxy-gcloud-sqlproxy.${var.astronomer_namespace}:5432"
+  db_connection_string = module.gcp.db_connection_string
+
   # If var.tls_cert is an empty string then the result is "var.tls_cert",
   # but otherwise it is the actual value of var.tls_cert.
   tls_cert = var.tls_cert == "" ? module.gcp.tls_cert : var.tls_cert

--- a/main.tf
+++ b/main.tf
@@ -112,8 +112,6 @@ module "system_components" {
 module "astronomer" {
   dependencies = [module.system_components.depended_on, module.gcp.depended_on]
 
-  #source  = "astronomer/astronomer/kubernetes"
-  #version = "1.1.90"
   source = "github.com/astronomer/terraform-kubernetes-astronomer?ref=gke-channels"
 
   astronomer_namespace            = var.astronomer_namespace
@@ -126,7 +124,7 @@ module "astronomer" {
   astronomer_helm_chart_repo      = var.astronomer_helm_chart_repo
   astronomer_helm_chart_repo_url  = var.astronomer_helm_chart_repo_url
 
-  db_connection_string = "postgres://${module.gcp.db_connection_user}:${module.gcp.db_connection_password}@pg-sqlproxy-gcloud-sqlproxy.astronomer:5432"
+  db_connection_string = "postgres://${module.gcp.db_connection_user}:${module.gcp.db_connection_password}@pg-sqlproxy-gcloud-sqlproxy.${var.astronomer_namespace}:5432"
   # If var.tls_cert is an empty string then the result is "var.tls_cert", 
   # but otherwise it is the actual value of var.tls_cert.
   tls_cert = var.tls_cert == "" ? module.gcp.tls_cert : var.tls_cert

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,9 @@ module "gcp" {
   # Kube version minimum
   kube_version_gke = var.kube_version_gke
 
+  # GKE Release channel
+  gke_release_channel = var.gke_release_channel
+
   # don't create A record - we intend to do so manually.
   do_not_create_a_record = var.do_not_create_a_record
 

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,8 @@
 # Networks, Database, Kubernetes cluster, etc.
 module "gcp" {
 
-  source =  "github.com/astronomer/terraform-google-astronomer-gcp?ref=gke-channels"
-  
+  source = "github.com/astronomer/terraform-google-astronomer-gcp?ref=gke-channels"
+
   email                   = var.email
   deployment_id           = var.deployment_id
   dns_managed_zone        = var.dns_managed_zone
@@ -83,7 +83,7 @@ module "gcp" {
 module "system_components" {
   dependencies = [module.gcp.depended_on]
 
- source = "github.com/astronomer/terraform-kubernetes-astronomer-system-components"
+  source = "github.com/astronomer/terraform-kubernetes-astronomer-system-components"
 
   astronomer_namespace               = var.astronomer_namespace
   enable_cloud_sql_proxy             = var.enable_cloud_sql_proxy
@@ -125,7 +125,7 @@ module "astronomer" {
   astronomer_helm_chart_repo_url  = var.astronomer_helm_chart_repo_url
 
   db_connection_string = "postgres://${module.gcp.db_connection_user}:${module.gcp.db_connection_password}@pg-sqlproxy-gcloud-sqlproxy.${var.astronomer_namespace}:5432"
-  # If var.tls_cert is an empty string then the result is "var.tls_cert", 
+  # If var.tls_cert is an empty string then the result is "var.tls_cert",
   # but otherwise it is the actual value of var.tls_cert.
   tls_cert = var.tls_cert == "" ? module.gcp.tls_cert : var.tls_cert
   tls_key  = var.tls_key == "" ? module.gcp.tls_key : var.tls_key

--- a/main.tf
+++ b/main.tf
@@ -83,8 +83,7 @@ module "gcp" {
 module "system_components" {
   dependencies = [module.gcp.depended_on]
 
-  source  = "astronomer/astronomer-system-components/kubernetes"
-  version = "0.1.19"
+ source = "https://github.com/astronomer/terraform-kubernetes-astronomer?ref=gke-channels"
 
   astronomer_namespace               = var.astronomer_namespace
   enable_cloud_sql_proxy             = var.enable_cloud_sql_proxy

--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,20 @@ module "gcp" {
   max_node_count_dynamic               = var.max_node_count_dynamic
   enable_gvisor_dynamic                = var.enable_gvisor_dynamic
   machine_type_dynamic                 = var.machine_type_dynamic
+  enable_dynamic_blue_node_pool        = var.enable_dynamic_blue_node_pool
+  dynamic_blue_np_initial_node_count   = var.dynamic_blue_np_initial_node_count
+  machine_type_dynamic_blue            = var.machine_type_dynamic_blue
+  disk_size_dynamic_blue               = var.disk_size_dynamic_blue
+  max_node_count_dynamic_blue          = var.max_node_count_dynamic_blue
+  dynamic_blue_node_pool_taints        = var.dynamic_blue_node_pool_taints
+  enable_gvisor_dynamic_blue           = var.enable_gvisor_dynamic_blue
+  enable_dynamic_green_node_pool       = var.enable_dynamic_green_node_pool
+  dynamic_green_np_initial_node_count  = var.dynamic_green_np_initial_node_count
+  machine_type_dynamic_green           = var.machine_type_dynamic_green
+  disk_size_dynamic_green              = var.disk_size_dynamic_green
+  max_node_count_dynamic_green         = var.max_node_count_dynamic_green
+  dynamic_green_node_pool_taints       = var.dynamic_green_node_pool_taints
+  enable_gvisor_dynamic_green          = var.enable_gvisor_dynamic_green
 }
 
 # Install tiller, which is the server-side component

--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ module "system_components" {
 module "astronomer" {
   dependencies = [module.system_components.depended_on, module.gcp.depended_on]
 
-  source = "github.com/astronomer/terraform-kubernetes-astronomer?ref=gke-channels"
+  source = "github.com/astronomer/terraform-kubernetes-astronomer?ref=1.1.90-1"
 
   astronomer_namespace            = var.astronomer_namespace
   install_astronomer_helm_chart   = var.install_astronomer_helm_chart

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ module "gcp" {
 module "system_components" {
   dependencies = [module.gcp.depended_on]
 
-  source = "github.com/astronomer/terraform-kubernetes-astronomer-system-components"
+  source = "github.com/astronomer/terraform-kubernetes-astronomer-system-components?ref=0.1.22"
 
   astronomer_namespace               = var.astronomer_namespace
   enable_cloud_sql_proxy             = var.enable_cloud_sql_proxy

--- a/variables.tf
+++ b/variables.tf
@@ -238,7 +238,7 @@ variable "max_node_count_platform_blue" {
 
 variable "platform_node_pool_taints_blue" {
   description = "Taints to apply to the platform node pool "
-  type        = list(map)
+  type        = list(map(string))
   default = [{
     effect = "NO_SCHEDULE"
     key    = "platform"
@@ -281,7 +281,7 @@ variable "max_node_count_platform_green" {
 
 variable "platform_node_pool_taints_green" {
   description = "Taints to apply to the Platform Node Pool "
-  type        = list(map)
+  type        = list(map(string))
   default = [{
     effect = "NO_SCHEDULE"
     key    = "platform"
@@ -322,7 +322,7 @@ variable "max_node_count_multi_tenant_blue" {
 
 variable "mt_node_pool_taints_blue" {
   description = "Taints to apply to the Multi-Tenant Node Pool "
-  type        = list(map)
+  type        = list(map(string))
   default     = []
 }
 
@@ -364,7 +364,7 @@ variable "max_node_count_multi_tenant_green" {
 
 variable "mt_node_pool_taints_green" {
   description = "Taints to apply to the Multi-Tenant Node Pool"
-  type        = list(map)
+  type        = list(map(string))
   default     = []
 }
 
@@ -396,7 +396,7 @@ variable "disk_size_dynamic" {
 
 variable "dynamic_node_pool_taints" {
   description = "Taints to apply to the dynamic node pool "
-  type        = list(map)
+  type        = list(map(string))
   default = [{
     effect = "NO_SCHEDULE"
     key    = "dynamic-pods"
@@ -452,7 +452,7 @@ variable "max_node_count_dynamic_blue" {
 
 variable "dynamic_blue_node_pool_taints" {
   description = "Taints to apply to the blue dynamic node pool"
-  type        = list(map)
+  type        = list(map(string))
   default = [{
     effect = "NO_SCHEDULE"
     key    = "dynamic-pods"
@@ -498,7 +498,7 @@ variable "max_node_count_dynamic_green" {
 
 variable "dynamic_green_node_pool_taints" {
   description = "Taints to apply to the green dynamic node pool"
-  type        = list(map)
+  type        = list(map(string))
   default = [{
     effect = "NO_SCHEDULE"
     key    = "dynamic-pods"

--- a/variables.tf
+++ b/variables.tf
@@ -452,7 +452,7 @@ variable "max_node_count_dynamic_blue" {
 
 variable "dynamic_blue_node_pool_taints" {
   description = "Taints to apply to the blue dynamic node pool"
-  type        = list(string)
+  type        = list(any)
   default = [{
     effect = "NO_SCHEDULE"
     key    = "dynamic-pods"
@@ -498,7 +498,7 @@ variable "max_node_count_dynamic_green" {
 
 variable "dynamic_green_node_pool_taints" {
   description = "Taints to apply to the green dynamic node pool"
-  type        = list(string)
+  type        = list(any)
   default = [{
     effect = "NO_SCHEDULE"
     key    = "dynamic-pods"

--- a/variables.tf
+++ b/variables.tf
@@ -560,3 +560,9 @@ variable "astronomer_namespace" {
   type        = string
   description = "The namespace that will be created and Astronomer will be installed"
 }
+
+variable "natgateway_external_ip_list" {
+  default     = []
+  type        = list
+  description = "this list is not actually of IPs, but of google URIs for the IP resource. example: https://www.googleapis.com/compute/v1/projects/astronomer-cloud-dev-236021/regions/us-east4/addresses/dev-nat-external-address-0"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -238,7 +238,7 @@ variable "max_node_count_platform_blue" {
 
 variable "platform_node_pool_taints_blue" {
   description = "Taints to apply to the platform node pool "
-  type        = list(any)
+  type        = list(map)
   default = [{
     effect = "NO_SCHEDULE"
     key    = "platform"
@@ -281,7 +281,7 @@ variable "max_node_count_platform_green" {
 
 variable "platform_node_pool_taints_green" {
   description = "Taints to apply to the Platform Node Pool "
-  type        = list(any)
+  type        = list(map)
   default = [{
     effect = "NO_SCHEDULE"
     key    = "platform"
@@ -322,7 +322,7 @@ variable "max_node_count_multi_tenant_blue" {
 
 variable "mt_node_pool_taints_blue" {
   description = "Taints to apply to the Multi-Tenant Node Pool "
-  type        = list(any)
+  type        = list(map)
   default     = []
 }
 
@@ -364,7 +364,7 @@ variable "max_node_count_multi_tenant_green" {
 
 variable "mt_node_pool_taints_green" {
   description = "Taints to apply to the Multi-Tenant Node Pool"
-  type        = list(any)
+  type        = list(map)
   default     = []
 }
 
@@ -396,7 +396,7 @@ variable "disk_size_dynamic" {
 
 variable "dynamic_node_pool_taints" {
   description = "Taints to apply to the dynamic node pool "
-  type        = list(any)
+  type        = list(map)
   default = [{
     effect = "NO_SCHEDULE"
     key    = "dynamic-pods"
@@ -452,7 +452,7 @@ variable "max_node_count_dynamic_blue" {
 
 variable "dynamic_blue_node_pool_taints" {
   description = "Taints to apply to the blue dynamic node pool"
-  type        = list(any)
+  type        = list(map)
   default = [{
     effect = "NO_SCHEDULE"
     key    = "dynamic-pods"
@@ -498,7 +498,7 @@ variable "max_node_count_dynamic_green" {
 
 variable "dynamic_green_node_pool_taints" {
   description = "Taints to apply to the green dynamic node pool"
-  type        = list(any)
+  type        = list(map)
   default = [{
     effect = "NO_SCHEDULE"
     key    = "dynamic-pods"

--- a/variables.tf
+++ b/variables.tf
@@ -130,6 +130,12 @@ variable "kube_version_gke" {
   description = "The kubernetes version to use in GKE"
 }
 
+variable "gke_release_channel" {
+  default     = "REGULAR"
+  type        = string
+  description = "The GKE Release channel to use. Blank for none"
+}
+
 variable "tiller_version" {
   default     = "2.16.1"
   description = "The version of tiller to install"

--- a/variables.tf
+++ b/variables.tf
@@ -126,7 +126,7 @@ variable "enable_velero" {
 
 # https://cloud.google.com/kubernetes-engine/docs/release-notes-regular
 variable "kube_version_gke" {
-  default     = "1.14.6-gke.2"
+  default     = "1.17.13-gke.2001"
   description = "The kubernetes version to use in GKE"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -445,6 +445,12 @@ variable "disk_size_dynamic_blue" {
   description = "Number of GB available on Nodes' local disks for the blue dynamic node pool"
 }
 
+variable "disk_type_dynamic_blue" {
+  default     = "pd-standard"
+  type        = string
+  description = "Type of the disk attached to each node (e.g. 'pd-standard', 'pd-balanced' or 'pd-ssd'). If unspecified, the default disk type is 'pd-standard'"
+}
+
 variable "max_node_count_dynamic_blue" {
   default     = 10
   description = "The approximate maximum number of nodes in the blue dynamic node pool. The exact max will be 3 * ceil(your_value / 3.0) in the case of regional cluster, and exactly as configured in the case of zonal cluster."
@@ -489,6 +495,12 @@ variable "disk_size_dynamic_green" {
   default     = 100
   type        = number
   description = "Number of GB available on Nodes' local disks for the green dynamic node pool"
+}
+
+variable "disk_type_dynamic_green" {
+  default     = "pd-standard"
+  type        = string
+  description = "Type of the disk attached to each node (e.g. 'pd-standard', 'pd-balanced' or 'pd-ssd'). If unspecified, the default disk type is 'pd-standard'"
 }
 
 variable "max_node_count_dynamic_green" {

--- a/variables.tf
+++ b/variables.tf
@@ -238,7 +238,7 @@ variable "max_node_count_platform_blue" {
 
 variable "platform_node_pool_taints_blue" {
   description = "Taints to apply to the platform node pool "
-  type        = list
+  type        = list(any)
   default = [{
     effect = "NO_SCHEDULE"
     key    = "platform"
@@ -281,7 +281,7 @@ variable "max_node_count_platform_green" {
 
 variable "platform_node_pool_taints_green" {
   description = "Taints to apply to the Platform Node Pool "
-  type        = list
+  type        = list(any)
   default = [{
     effect = "NO_SCHEDULE"
     key    = "platform"
@@ -322,7 +322,7 @@ variable "max_node_count_multi_tenant_blue" {
 
 variable "mt_node_pool_taints_blue" {
   description = "Taints to apply to the Multi-Tenant Node Pool "
-  type        = list
+  type        = list(any)
   default     = []
 }
 
@@ -364,7 +364,7 @@ variable "max_node_count_multi_tenant_green" {
 
 variable "mt_node_pool_taints_green" {
   description = "Taints to apply to the Multi-Tenant Node Pool"
-  type        = list
+  type        = list(any)
   default     = []
 }
 
@@ -374,7 +374,7 @@ variable "enable_gvisor_green" {
   description = "Should this module configure the multi-tenant node pool for the gvisor runtime?"
 }
 
-## Dynamic node pool: we do not have Blue / Green for this one, just a single node pool
+## Dynamic node pool (legacy, pre-dynamic-blue-green pool)
 
 variable "create_dynamic_pods_nodepool" {
   type        = bool
@@ -396,14 +396,13 @@ variable "disk_size_dynamic" {
 
 variable "dynamic_node_pool_taints" {
   description = "Taints to apply to the dynamic node pool "
-  type        = list
+  type        = list(any)
   default = [{
     effect = "NO_SCHEDULE"
     key    = "dynamic-pods"
     value  = "true"
   }, ]
 }
-
 
 variable "max_node_count_dynamic" {
   default     = 10
@@ -420,6 +419,100 @@ variable "machine_type_dynamic" {
   default     = "n1-standard-16"
   description = "The GCP machine type for the bastion"
 }
+
+## Dynamic node pool blue (added 2020-12-16)
+
+variable "enable_dynamic_blue_node_pool" {
+  type        = bool
+  default     = false
+  description = "Turn on the blue dynamic node pool"
+}
+
+variable "dynamic_blue_np_initial_node_count" {
+  type        = number
+  default     = 1
+  description = "Initial node count for the blue dynamic node pool"
+}
+
+variable "machine_type_dynamic_blue" {
+  default     = "n1-standard-16"
+  description = "The GCP machine type for the blue dynamic node pool"
+}
+
+variable "disk_size_dynamic_blue" {
+  default     = 100
+  type        = number
+  description = "Number of GB available on Nodes' local disks for the blue dynamic node pool"
+}
+
+variable "max_node_count_dynamic_blue" {
+  default     = 10
+  description = "The approximate maximum number of nodes in the blue dynamic node pool. The exact max will be 3 * ceil(your_value / 3.0) in the case of regional cluster, and exactly as configured in the case of zonal cluster."
+}
+
+variable "dynamic_blue_node_pool_taints" {
+  description = "Taints to apply to the blue dynamic node pool"
+  type        = list(string)
+  default = [{
+    effect = "NO_SCHEDULE"
+    key    = "dynamic-pods"
+    value  = "true"
+  }, ]
+}
+
+variable "enable_gvisor_dynamic_blue" {
+  type        = bool
+  default     = false
+  description = "Should gvisor be enabled for the blue dynamic node pool?"
+}
+
+## Dynamic node pool green (added 2020-12-16)
+
+variable "enable_dynamic_green_node_pool" {
+  type        = bool
+  default     = false
+  description = "Turn on the green dynamic node pool"
+}
+
+variable "dynamic_green_np_initial_node_count" {
+  type        = number
+  default     = 1
+  description = "Initial node count for the green dynamic node pool"
+}
+
+variable "machine_type_dynamic_green" {
+  default     = "n1-standard-16"
+  description = "The GCP machine type for the green dynamic node pool"
+}
+
+variable "disk_size_dynamic_green" {
+  default     = 100
+  type        = number
+  description = "Number of GB available on Nodes' local disks for the green dynamic node pool"
+}
+
+variable "max_node_count_dynamic_green" {
+  default     = 10
+  description = "The approximate maximum number of nodes in the green dynamic node pool. The exact max will be 3 * ceil(your_value / 3.0) in the case of regional cluster, and exactly as configured in the case of zonal cluster."
+}
+
+variable "dynamic_green_node_pool_taints" {
+  description = "Taints to apply to the green dynamic node pool"
+  type        = list(string)
+  default = [{
+    effect = "NO_SCHEDULE"
+    key    = "dynamic-pods"
+    value  = "true"
+  }, ]
+}
+
+variable "enable_gvisor_dynamic_green" {
+  type        = bool
+  default     = false
+  description = "Should gvisor be enabled for the green dynamic node pool?"
+}
+
+## Additional configs
 
 variable "install_astronomer_helm_chart" {
   type        = bool


### PR DESCRIPTION
Logic to switch clusters away from specifying versions onto GKE Channels where versions are managed by GKE.

This PR only has the logic we've been using. There is still work to do to get CI working and to migrate to TF 0.13