### PR TITLE
Astronomer db connection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -141,7 +141,8 @@ module "astronomer" {
   astronomer_helm_chart_repo      = var.astronomer_helm_chart_repo
   astronomer_helm_chart_repo_url  = var.astronomer_helm_chart_repo_url
 
-  db_connection_string = "postgres://${module.gcp.db_connection_user}:${module.gcp.db_connection_password}@pg-sqlproxy-gcloud-sqlproxy.${var.astronomer_namespace}:5432"
+  db_connection_string = module.gcp.db_connection_string
+
   # If var.tls_cert is an empty string then the result is "var.tls_cert",
   # but otherwise it is the actual value of var.tls_cert.
   tls_cert = var.tls_cert == "" ? module.gcp.tls_cert : var.tls_cert


### PR DESCRIPTION
First step to removing the postgresql proxy in gcp. Just changing the db connection string for now, rather than fully removing the proxy. This will allow astronomer components to by-pass the proxy. There are users of the proxy outside of the astronomer components that is why I'm not removing the proxy yet. 

work for issue https://github.com/astronomer/issues/issues/1545