### PR TITLE
Move db_max_connections to var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ module "gcp" {
   lets_encrypt = var.lets_encrypt
 
   cloud_sql_tier     = var.db_instance_size
-  db_max_connections = 2000
+  db_max_connections = var.db_max_connections
 
   # Enable KEDA
   webhook_ports = ["6443"]

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,11 @@ variable "db_instance_size" {
   type    = string
 }
 
+variable "db_max_connections" {
+  default = 2000
+  type    = number
+}
+
 variable "stripe_secret_key" {
   default = ""
   type    = string


### PR DESCRIPTION
This replaces the static assignment of `db_max_connections = 2000` with a variable that can be used. Needed for https://github.com/astronomer/google-environments/pull/241

There is currently no CI on this repo, but this TF plan will show that this change works: <https://app.circleci.com/pipelines/github/astronomer/google-environments/8783/workflows/32538ad6-c02b-4897-9e3a-d6a0bb00bfee/jobs/14658/parallel-runs/0/steps/0-102>